### PR TITLE
Resolve promise on completing drawImage

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -338,28 +338,29 @@ function calculateGroups(values: rgba[]) {
 async function printImage(settings: imageSettings): Promise < void > {
   const outputStrings = await getImageStrings(settings);
 
-  //const width = stringWidth(outputStrings[0].split("\n")[0]);
-  const height = (outputStrings[0]?.match(/\n/g)?.length ?? 0) + 1;
-  tty.hideCursorSync();
-
-  //If it is an animation, add an extra frame so we end where we started.
-  const numFrames = outputStrings.length === 1 ? 1 : outputStrings.length * (settings.animationLoops ?? 1) + 1;
-
-  for (let frameIndex = 0; frameIndex < numFrames; frameIndex++) {
-    setTimeout(async () => {
-      
-      console.log(outputStrings[frameIndex%outputStrings.length])
-
-      if (frameIndex === numFrames - 1) {
-        // tty.goDownSync(height + 2);
-        tty.showCursor();
-
-      }else{
-        tty.goUpSync(height);
-      }
-    }, frameIndex * 200);
-
-  }
+  return new Promise((resolve) => {
+    //const width = stringWidth(outputStrings[0].split("\n")[0]);
+    const height = (outputStrings[0]?.match(/\n/g)?.length ?? 0) + 1;
+    tty.hideCursorSync();
+  
+    //If it is an animation, add an extra frame so we end where we started.
+    const numFrames = outputStrings.length === 1 ? 1 : outputStrings.length * (settings.animationLoops ?? 1) + 1;
+  
+    for (let frameIndex = 0; frameIndex < numFrames; frameIndex++) {
+      setTimeout(async () => {
+        
+        console.log(outputStrings[frameIndex%outputStrings.length])
+  
+        if (frameIndex === numFrames - 1) {
+          // tty.goDownSync(height + 2);
+          tty.showCursorSync();
+          resolve();
+        }else{
+          tty.goUpSync(height);
+        }
+      }, frameIndex * 200);
+    }
+  })
 }
 
 function colorDistance(color1: rgba, color2: rgba) {


### PR DESCRIPTION
Hey not sure you're taking PRs but I hit an issue that I fixed locally so thought I'd share the solution. The issue I had was the promise for `printImage` was resolving before the image is actually drawn.

For example:
```
await printImage({
  path: "https://deno.land/images/deno_city.jpeg",
  width: 20,
});

console.log("This should be logged after image is printed!");
```
Results in the following output:

<img src="https://user-images.githubusercontent.com/5631627/141660533-29541e83-0e5c-4710-ba94-99380176988b.png" width="50%" height="50%">



This PR adds a promise resolve once final frame is drawn, which allows proper await behaviour. Have also replaced `showCursor` with `showCursorSync` to avoid issues with sharing stdout resource.

With the fix, the output for the script above is:

<img src="https://user-images.githubusercontent.com/5631627/141660669-dbfaa846-02ca-4599-83c2-a0b79fb8206d.png" width="50%" height="50%">